### PR TITLE
Fix cash flow button layout

### DIFF
--- a/packages/desktop-client/src/components/reports/CategorySelector.tsx
+++ b/packages/desktop-client/src/components/reports/CategorySelector.tsx
@@ -3,10 +3,10 @@ import React, { Fragment, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
-import { Text } from '@actual-app/components/text';
-import { View } from '@actual-app/components/view';
 import { styles } from '@actual-app/components/styles';
+import { Text } from '@actual-app/components/text';
 import { Tooltip } from '@actual-app/components/tooltip';
+import { View } from '@actual-app/components/view';
 
 import {
   type CategoryEntity,

--- a/packages/desktop-client/src/components/reports/CategorySelector.tsx
+++ b/packages/desktop-client/src/components/reports/CategorySelector.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@actual-app/components/button';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
+import { styles } from '@actual-app/components/styles';
+import { Tooltip } from '@actual-app/components/tooltip';
 
 import {
   type CategoryEntity,
@@ -74,33 +76,65 @@ export function CategorySelector({
           flexShrink: 0,
         }}
       >
-        <Button
-          variant="bare"
-          onPress={() => setUncheckedHidden(state => !state)}
-          style={{ padding: 8 }}
+        <Tooltip
+          placement="bottom start"
+          content={
+            <Text>
+              {uncheckedHidden ? t('Show unchecked') : t('Hide unchecked')}
+            </Text>
+          }
+          style={{
+            ...styles.tooltip,
+            lineHeight: 1.5,
+            padding: '6px 10px',
+          }}
         >
-          <View>
-            {uncheckedHidden ? (
-              <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-                <SvgViewShow
-                  width={15}
-                  height={15}
-                  style={{ marginRight: 5 }}
-                />
-                <Text>{t('Show unchecked')}</Text>
-              </View>
-            ) : (
-              <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-                <SvgViewHide
-                  width={15}
-                  height={15}
-                  style={{ marginRight: 5 }}
-                />
-                <Text>{t('Hide unchecked')}</Text>
-              </View>
-            )}
-          </View>
-        </Button>
+          <Button
+            variant="bare"
+            onPress={() => setUncheckedHidden(state => !state)}
+            style={{ padding: 8 }}
+          >
+            <View>
+              {uncheckedHidden ? (
+                <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                  <SvgViewShow
+                    width={15}
+                    height={15}
+                    style={{ marginRight: 5 }}
+                  />
+                  <Text
+                    style={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      maxWidth: '104px',
+                    }}
+                  >
+                    {t('Show unchecked')}
+                  </Text>
+                </View>
+              ) : (
+                <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                  <SvgViewHide
+                    width={15}
+                    height={15}
+                    style={{ marginRight: 5 }}
+                  />
+                  <Text
+                    style={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      maxWidth: '104px',
+                    }}
+                  >
+                    {t('Hide unchecked')}
+                  </Text>
+                </View>
+              )}
+            </View>
+          </Button>
+        </Tooltip>
         <View style={{ flex: 1 }} />
         <View style={{ flexDirection: 'row', alignItems: 'center' }}>
           <GraphButton

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -63,6 +63,7 @@ type CashFlowInnerProps = {
   widget?: CashFlowWidget;
 };
 
+// TODO: Fix cash flow report edit view
 function CashFlowInner({ widget }: CashFlowInnerProps) {
   const dispatch = useDispatch();
   const { t } = useTranslation();

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -63,7 +63,6 @@ type CashFlowInnerProps = {
   widget?: CashFlowWidget;
 };
 
-// TODO: Fix cash flow report edit view
 function CashFlowInner({ widget }: CashFlowInnerProps) {
   const dispatch = useDispatch();
   const { t } = useTranslation();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

## What
Fixed an issue where the Hide/Show unchecked button text overflows when using other languages that has more letters than the default, distorting the buttons on the right.

## Why
- The current styling for ‘Hide/Show unchecked' button text doesn’t have a workaround for translations that make the text longer than the default one. This leads to overflow and distorts the buttons on the right.

## How
- Added styling for overflows
- Added an ellipsis when overflowing to indicate long text being hidden
- Added a tooltip that shows the full text when hovered