### PR TITLE
Fix fatal error on split transactions

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -2058,7 +2058,7 @@ export const TransactionTable = forwardRef((props, ref) => {
         t => t.id === splitsExpanded.state.transitionId,
       );
       result = props.transactions.filter((t, idx) => {
-        if (t.parent_id) {
+        if (t && t.parent_id) {
           if (idx >= index) {
             return splitsExpanded.isExpanded(t.parent_id);
           } else if (prevSplitsExpanded.current) {
@@ -2078,7 +2078,7 @@ export const TransactionTable = forwardRef((props, ref) => {
       prevSplitsExpanded.current = splitsExpanded;
 
       result = props.transactions.filter(t => {
-        if (t.parent_id) {
+        if (t && t.parent_id) {
           return splitsExpanded.isExpanded(t.parent_id);
         }
         return true;

--- a/packages/loot-core/src/shared/transactions.test.ts
+++ b/packages/loot-core/src/shared/transactions.test.ts
@@ -206,4 +206,31 @@ describe('Transactions', () => {
       expect.objectContaining({ amount: 3002 }),
     ]);
   });
+
+  test('converts parent to regular transaction when all subtransactions are deleted', () => {
+    const transactions = [
+      makeTransaction({ amount: 2001 }),
+      ...makeSplitTransaction({ id: 't1', amount: 2500 }, [
+        { id: 't2', amount: 2000 },
+        { id: 't3', amount: 500 },
+      ]),
+      makeTransaction({ amount: 3002 }),
+    ];
+
+    let result = deleteTransaction(transactions, 't2');
+    result = deleteTransaction(result.data, 't3');
+
+    expect(result.data).toEqual([
+      expect.objectContaining({ amount: 2001 }),
+      expect.objectContaining({
+        id: 't1',
+        amount: 2500,
+        is_parent: false,
+        error: null,
+      }),
+      expect.objectContaining({ amount: 3002 }),
+    ]);
+
+    expect(result.data.find(t => t.parent_id)).toBeFalsy();
+  });
 });

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -281,17 +281,22 @@ export function deleteTransaction(
     if (trans.is_parent) {
       if (trans.id === id) {
         return null;
-      } else if (trans.subtransactions?.length === 1) {
-        const { error, subtransactions, ...rest } = trans;
-        return {
-          ...rest,
-          is_parent: false,
-        } satisfies TransactionEntity;
       } else {
         const sub = trans.subtransactions?.filter(t => t.id !== id);
+
+        if (!sub || sub.length === 0) {
+          const converted = {
+            ...trans,
+            is_parent: false,
+            error: null,
+            subtransactions: undefined
+          } satisfies TransactionEntity;
+          return converted;
+        }
+
         return recalculateSplit({
           ...trans,
-          ...(sub && { subtransactions: sub }),
+          subtransactions: sub,
         });
       }
     } else {

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -273,6 +273,7 @@ export function updateTransaction(
   });
 }
 
+// TODO: Fix split transaction length fatal error
 export function deleteTransaction(
   transactions: TransactionEntity[],
   id: string,

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -289,7 +289,7 @@ export function deleteTransaction(
             ...trans,
             is_parent: false,
             error: null,
-            subtransactions: undefined
+            subtransactions: undefined,
           } satisfies TransactionEntity;
           return converted;
         }

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -273,7 +273,6 @@ export function updateTransaction(
   });
 }
 
-// TODO: Fix split transaction length fatal error
 export function deleteTransaction(
   transactions: TransactionEntity[],
   id: string,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

## What
Fixed a fatal error where when there are no subtransactions left in a split transaction.

## Why
- The current styling for ‘Hide/Show unchecked' button text doesn’t have a workaround for translations that make the text longer than the default one. This leads to overflow and distorts the buttons on the right
- The UI code attempts to read `subtransactions.length` without proper null checks
- The current code doesn't properly convert a parent transaction to a regular transaction when all its children are removed

## How
- Modified the `deleteTransaction` function to properly handle the conversion from split to regular transaction when all child transactions are deleted