### PR TITLE
Increase minHeight of Popover

### DIFF
--- a/packages/desktop-client/src/components/select/RecurringSchedulePicker.tsx
+++ b/packages/desktop-client/src/components/select/RecurringSchedulePicker.tsx
@@ -611,7 +611,7 @@ export function RecurringSchedulePicker({
 
       <Popover
         triggerRef={triggerRef}
-        style={{ padding: 10, width: 380 }}
+        style={{ padding: 10, width: 380, minHeight: 280 }}
         placement="bottom start"
         isOpen={isOpen}
         onOpenChange={() => setIsOpen(false)}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

## What
Fixed an issue when the date selector in schedule pop-up closes and doesn't apply the selected date if the date is in the 6th row of the month.

## Why
- The date picker of Actual uses the `Pikaday` module, which doesn't stop the click propagation when clicking on a date. It selects the date immediately after pressing down left click. When the current month in the date picker has 6 rows, the part of the 6th row is outside the parent popover below it. Since `Pikaday` doesn't have click stop propagation, the click on date selection also applies to the parent popover, which leads to closing it if the click is outside it.

Any click outside the red rectangle below closes both popovers
![image](https://github.com/user-attachments/assets/0b090c00-608f-43ef-9606-3f5d0b613dbd)

## How
- Tried adding stop propagations in the code, but for some reason it stops on some parts of the popover, but not when selecting a date
- For a temporary workaround, added `minHeight` on the parent popover for the `Pikaday` popover to be inside of the parent popover always